### PR TITLE
Update climate preset icons and translations for Auto mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.2] - 2026-05-09
+
+### Changed
+
+- Updated climate preset presentation in Auto mode to use clearer names and icons:
+  - `program` is shown as **Program** with a home icon
+  - `defrost` behavior is shown as **Eco 15°C** with a leaf icon
+  - `boost` behavior is shown as **Comfort 23°C** with a comfort icon
+- Updated localized translations (EN/DE/FR/CS/SK) for climate preset labels and sensor preset labels to match the new naming
+
+### Fixed
+
+- Fixed preset picker icon behavior in Home Assistant by mapping exposed climate preset keys to icon-aware semantic values (`home`, `eco`, `comfort`)
+- Kept backward compatibility for service calls by accepting legacy preset aliases (`program`, `defrost`, `boost`)
+
+---
+
 ## [1.2.1] - 2026-04-28
 
 ### Changed

--- a/custom_components/fenix_tft/climate.py
+++ b/custom_components/fenix_tft/climate.py
@@ -72,6 +72,15 @@ PRESET_INVERTED: dict[str, int] = {
     "boost": PRESET_MODE_BOOST,
 }
 
+PRESET_CANONICAL_MAP: dict[str, str] = {
+    "home": "home",
+    "program": "home",
+    "eco": "eco",
+    "defrost": "eco",
+    "comfort": "comfort",
+    "boost": "comfort",
+}
+
 PRESET_ICON_MAP: dict[str, str] = {
     "home": "mdi:home",
     "eco": "mdi:leaf",
@@ -113,6 +122,7 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
         "eco",  # Eco hold (15°C)
         "comfort",  # Comfort hold (23°C)
     ]
+    _normalized_preset_modes: ClassVar[frozenset[str]] = frozenset(PRESET_INVERTED)
 
     _attr_temperature_unit: ClassVar[str] = UnitOfTemperature.CELSIUS
     _attr_min_temp: ClassVar[float] = TEMP_MIN
@@ -193,7 +203,9 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
         """Return an icon that reflects the active preset mode in auto operation."""
         preset = self.preset_mode
         if preset is not None:
-            return PRESET_ICON_MAP.get(preset.lower(), super().icon)
+            icon = PRESET_ICON_MAP.get(preset.lower())
+            if icon is not None:
+                return icon
         return super().icon
 
     @property
@@ -361,6 +373,12 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
         # Force entity state update in Home Assistant
         self.async_write_ha_state()
 
+    async def async_handle_set_preset_mode_service(self, preset_mode: str) -> None:
+        """Handle preset mode service calls with backward-compatible aliases."""
+        normalized_preset = preset_mode.lower()
+        canonical_preset = PRESET_CANONICAL_MAP.get(normalized_preset, preset_mode)
+        await super().async_handle_set_preset_mode_service(canonical_preset)
+
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode for special operations."""
         if self._is_holiday_active():
@@ -372,13 +390,12 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
             raise HomeAssistantError(msg)
 
         normalized_preset = preset_mode.lower()
-        valid_presets = [mode.lower() for mode in self._attr_preset_modes]
-        if normalized_preset not in valid_presets:
+        if normalized_preset not in self._normalized_preset_modes:
             _LOGGER.warning(
                 "Unsupported preset mode for device %s: %s (valid: %s)",
                 self._device_id,
                 preset_mode,
-                self._attr_preset_modes,
+                sorted(self._normalized_preset_modes),
             )
             return
 

--- a/custom_components/fenix_tft/climate.py
+++ b/custom_components/fenix_tft/climate.py
@@ -56,14 +56,27 @@ HVAC_MODE_MAP: dict[int, str] = {
     PRESET_MODE_MANUAL: "manual",  # Manual temperature control
 }
 
-# Map device preset_mode values to Home Assistant preset mode strings
-# Note: PRESET_MODE_PROGRAM (2) appears in both maps - shows as AUTO + "program"
+# Map device preset_mode values to Home Assistant preset mode strings.
+# Note: PRESET_MODE_PROGRAM (2) appears in both maps - shows as AUTO + "program".
 PRESET_MAP: dict[int, str] = {
-    PRESET_MODE_PROGRAM: "program",  # Follow programmed schedule
-    PRESET_MODE_DEFROST: "defrost",  # Defrost cycle
-    PRESET_MODE_BOOST: "boost",  # Boost heating mode
+    PRESET_MODE_PROGRAM: "home",  # Follow programmed schedule
+    PRESET_MODE_DEFROST: "eco",  # Eco hold (15°C)
+    PRESET_MODE_BOOST: "comfort",  # Comfort hold (23°C)
 }
-PRESET_INVERTED: dict[str, int] = {v: k for k, v in PRESET_MAP.items()}
+PRESET_INVERTED: dict[str, int] = {
+    "home": PRESET_MODE_PROGRAM,
+    "program": PRESET_MODE_PROGRAM,
+    "eco": PRESET_MODE_DEFROST,
+    "defrost": PRESET_MODE_DEFROST,
+    "comfort": PRESET_MODE_BOOST,
+    "boost": PRESET_MODE_BOOST,
+}
+
+PRESET_ICON_MAP: dict[str, str] = {
+    "home": "mdi:home",
+    "eco": "mdi:leaf",
+    "comfort": "mdi:sofa",
+}
 
 
 async def async_setup_entry(
@@ -96,9 +109,9 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
 
     # Define supported preset modes for special operations
     _attr_preset_modes: ClassVar[list[str]] = [
-        "program",  # Follow programmed schedule
-        "defrost",  # Defrost cycle
-        "boost",  # Boost heating
+        "home",  # Follow programmed schedule
+        "eco",  # Eco hold (15°C)
+        "comfort",  # Comfort hold (23°C)
     ]
 
     _attr_temperature_unit: ClassVar[str] = UnitOfTemperature.CELSIUS
@@ -174,6 +187,14 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
         preset = self._get_preset_mode()
         # Only return preset if it's in our supported modes list
         return preset if preset in self._attr_preset_modes else None
+
+    @property
+    def icon(self) -> str | None:
+        """Return an icon that reflects the active preset mode in auto operation."""
+        preset = self.preset_mode
+        if preset is not None:
+            return PRESET_ICON_MAP.get(preset.lower(), super().icon)
+        return super().icon
 
     @property
     def supported_features(self) -> ClimateEntityFeature:
@@ -350,7 +371,9 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
             msg = HOLIDAY_LOCKED_MSG
             raise HomeAssistantError(msg)
 
-        if preset_mode not in self._attr_preset_modes:
+        normalized_preset = preset_mode.lower()
+        valid_presets = [mode.lower() for mode in self._attr_preset_modes]
+        if normalized_preset not in valid_presets:
             _LOGGER.warning(
                 "Unsupported preset mode for device %s: %s (valid: %s)",
                 self._device_id,
@@ -360,7 +383,7 @@ class FenixTFTClimate(FenixTFTEntity, ClimateEntity):
             return
 
         # Convert preset mode string to device value
-        preset_value = PRESET_INVERTED[preset_mode]
+        preset_value = PRESET_INVERTED[normalized_preset]
         _LOGGER.debug(
             "Setting preset mode for device %s: %s (preset_mode=%s)",
             self._device_id,

--- a/custom_components/fenix_tft/manifest.json
+++ b/custom_components/fenix_tft/manifest.json
@@ -17,5 +17,5 @@
         "aiohttp>=3.8.0",
         "beautifulsoup4>=4.11.0"
     ],
-    "version": "1.2.1"
+    "version": "1.2.2"
 }

--- a/custom_components/fenix_tft/translations/cs.json
+++ b/custom_components/fenix_tft/translations/cs.json
@@ -56,7 +56,16 @@
   "entity": {
     "climate": {
       "thermostat": {
-        "name": "Termostat"
+        "name": "Termostat",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "home": "Program",
+              "eco": "Eco 15°C",
+              "comfort": "Komfort 23°C"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -81,8 +90,8 @@
           "off": "Vypnuto",
           "holidays": "Prázdniny",
           "program": "Program",
-          "defrost": "Odmrazování",
-          "boost": "Boost",
+          "defrost": "Eco 15°C",
+          "boost": "Komfort 23°C",
           "manual": "Manuální"
         }
       },

--- a/custom_components/fenix_tft/translations/de.json
+++ b/custom_components/fenix_tft/translations/de.json
@@ -56,7 +56,16 @@
   "entity": {
     "climate": {
       "thermostat": {
-        "name": "Thermostat"
+        "name": "Thermostat",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "home": "Programm",
+              "eco": "Eco 15°C",
+              "comfort": "Komfort 23°C"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -81,8 +90,8 @@
           "off": "Aus",
           "holidays": "Urlaub",
           "program": "Programm",
-          "defrost": "Abtauen",
-          "boost": "Boost",
+          "defrost": "Eco 15°C",
+          "boost": "Komfort 23°C",
           "manual": "Manuell"
         }
       },

--- a/custom_components/fenix_tft/translations/en.json
+++ b/custom_components/fenix_tft/translations/en.json
@@ -56,7 +56,16 @@
   "entity": {
     "climate": {
       "thermostat": {
-        "name": "Thermostat"
+        "name": "Thermostat",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "home": "Program",
+              "eco": "Eco 15°C",
+              "comfort": "Comfort 23°C"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -81,8 +90,8 @@
           "off": "Off",
           "holidays": "Holidays",
           "program": "Program",
-          "defrost": "Defrost",
-          "boost": "Boost",
+          "defrost": "Eco 15°C",
+          "boost": "Comfort 23°C",
           "manual": "Manual"
         }
       },

--- a/custom_components/fenix_tft/translations/fr.json
+++ b/custom_components/fenix_tft/translations/fr.json
@@ -56,7 +56,16 @@
   "entity": {
     "climate": {
       "thermostat": {
-        "name": "Thermostat"
+        "name": "Thermostat",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "home": "Programme",
+              "eco": "Éco 15°C",
+              "comfort": "Confort 23°C"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -81,8 +90,8 @@
           "off": "Éteint",
           "holidays": "Vacances",
           "program": "Programme",
-          "defrost": "Dégivrage",
-          "boost": "Boost",
+          "defrost": "Éco 15°C",
+          "boost": "Confort 23°C",
           "manual": "Manuel"
         }
       },

--- a/custom_components/fenix_tft/translations/sk.json
+++ b/custom_components/fenix_tft/translations/sk.json
@@ -56,7 +56,16 @@
   "entity": {
     "climate": {
       "thermostat": {
-        "name": "Termostat"
+        "name": "Termostat",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "home": "Program",
+              "eco": "Eco 15°C",
+              "comfort": "Komfort 23°C"
+            }
+          }
+        }
       }
     },
     "sensor": {
@@ -81,8 +90,8 @@
           "off": "Vypnuté",
           "holidays": "Dovolenka",
           "program": "Program",
-          "defrost": "Odmrazovanie",
-          "boost": "Zrýchlenie",
+          "defrost": "Eco 15°C",
+          "boost": "Komfort 23°C",
           "manual": "Manuálny"
         }
       },

--- a/tests/components/fenix_tft/test_climate.py
+++ b/tests/components/fenix_tft/test_climate.py
@@ -204,7 +204,7 @@ async def test_set_preset_mode(hass, setup_integration, mock_api):
     await hass.services.async_call(
         "climate",
         "set_preset_mode",
-        {"entity_id": entity_id, "preset_mode": "program"},
+        {"entity_id": entity_id, "preset_mode": "home"},
         blocking=True,
     )
 

--- a/tests/components/fenix_tft/test_climate.py
+++ b/tests/components/fenix_tft/test_climate.py
@@ -10,6 +10,8 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.fenix_tft.const import (
+    PRESET_MODE_BOOST,
+    PRESET_MODE_DEFROST,
     PRESET_MODE_MANUAL,
     PRESET_MODE_OFF,
     PRESET_MODE_PROGRAM,
@@ -210,6 +212,39 @@ async def test_set_preset_mode(hass, setup_integration, mock_api):
 
     mock_api.set_device_preset_mode.assert_called_once_with(
         MOCK_DEVICE_ID, PRESET_MODE_PROGRAM
+    )
+
+
+@pytest.mark.parametrize(
+    ("preset_mode", "expected_preset_value"),
+    [
+        ("home", PRESET_MODE_PROGRAM),
+        ("program", PRESET_MODE_PROGRAM),
+        ("eco", PRESET_MODE_DEFROST),
+        ("defrost", PRESET_MODE_DEFROST),
+        ("comfort", PRESET_MODE_BOOST),
+        ("boost", PRESET_MODE_BOOST),
+    ],
+)
+async def test_set_preset_mode_legacy_and_new_names(
+    hass,
+    setup_integration,
+    mock_api,
+    preset_mode,
+    expected_preset_value,
+):
+    """Test legacy and new preset names map to the expected device value."""
+    entity_id = _get_climate_entity_id(hass)
+
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": entity_id, "preset_mode": preset_mode},
+        blocking=True,
+    )
+
+    mock_api.set_device_preset_mode.assert_called_once_with(
+        MOCK_DEVICE_ID, expected_preset_value
     )
 
 


### PR DESCRIPTION
## Summary by Sourcery

Update climate preset naming and icons for Auto mode while preserving backwards compatibility, and bump integration version.

New Features:
- Expose semantic home/eco/comfort climate presets with associated icons in Home Assistant.

Bug Fixes:
- Ensure preset picker icons render correctly by mapping preset keys to icon-aware semantic values and normalizing input.
- Maintain compatibility for service calls by accepting legacy preset aliases for presets.

Enhancements:
- Align supported preset modes and internal mappings with clearer home/eco/comfort semantics instead of program/defrost/boost.

Documentation:
- Document the new climate preset names, icons, and localization updates in the changelog.

Tests:
- Update climate preset tests to cover the new default preset name used in service calls.

Chores:
- Update translations for multiple locales to reflect the new climate preset naming and bump the integration manifest version.