### PR TITLE
feat: Add full-history energy statistics import and batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.0] - 2026-05-10
+
+### Added
+
+- Full-history energy statistics import via `fenix_tft.import_historical_statistics` with the new `import_all_history` option
+- Yearly batching for very old history ranges so long backfills can progress efficiently
+
+### Changed
+
+- `days_back` is now optional with a default of 30 days for targeted historical backfills
+- Updated service descriptions, README documentation, and localized translations for the new full-history import flow
+
+### Fixed
+
+- Historical backfills now rebase later external statistic sums when prepending older data, keeping cumulative totals continuous
+- Historical import notifications now better reflect imported ranges, batch progress, and up-to-date cases
+
+---
+
 ## [1.2.2] - 2026-05-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Here is the thermostat integration in action.
 
 ## Features
 
-### ✅ Current Features
-
 - **Climate Control**: Temperature control (5–35 °C, 0.5 °C precision), heating modes (Off/Manual/Program), real-time monitoring
 - **Energy Monitoring**: Daily consumption tracking with Home Assistant Energy Dashboard integration
 - **Holiday Mode**: Set and cancel holiday schedules with automatic control locking during holidays
@@ -36,12 +34,7 @@ Here is the thermostat integration in action.
 - **Diagnostics**: Built-in diagnostics panel for troubleshooting (redacts sensitive data)
 - **Repair Issues**: Automatic repair notification after repeated cloud connectivity failures
 - **API Resilience**: Automatic retry with exponential backoff for transient server errors
-
-### 🚧 Planned & Ideas
-
-- **Smart Scheduling**: Full scheduling system, calendar integration
-- **Enhanced Diagnostics**: Additional device sensors and operational data
-- **Energy Import Deduplication**: Smarter re-import detection to skip already-imported periods
+- **Energy Import Deduplication**: Re-import aware historical import that backfills only missing older periods to prevent duplicate statistics and double-counting
 
 ### 💡 Contributing
 
@@ -196,13 +189,15 @@ Import historical energy consumption data as external statistics. This service i
 **Parameters:**
 
 - `energy_entity` (required): Energy sensor to import data for (e.g., `sensor.bedroom_daily_energy_consumption`)
-- `days_back` (required): Number of days of historical data to import (1-365)
+- `days_back` (optional): Number of days of historical data to import (1-365). Ignored when `import_all_history: true`
+- `import_all_history` (optional): Import all available historical data in progressive yearly batches instead of a fixed day range
 
 **Behavior:**
 
 - If no statistics exist: Imports data starting from the requested number of days ago, ending at midnight of today (start of current day in your timezone) to avoid overlap with today's sensor data
 - If statistics exist: Detects the first recorded data point and imports the requested number of days ending at midnight of the day when existing data begins, ensuring no overlap
 - Example: If data exists from Oct 25 10:00 and you request 30 days, it imports Sept 25 00:00 to Oct 25 00:00 (midnight boundaries)
+- If `import_all_history` is enabled: Walks backwards in yearly batches, prepending older statistics and rebasing later cumulative sums so the imported history stays continuous
 
 **Example service call:**
 
@@ -211,6 +206,15 @@ service: fenix_tft.import_historical_statistics
 data:
   energy_entity: sensor.bedroom_daily_energy_consumption
   days_back: 30
+```
+
+**Example full-history import:**
+
+```yaml
+service: fenix_tft.import_historical_statistics
+data:
+  energy_entity: sensor.bedroom_daily_energy_consumption
+  import_all_history: true
 ```
 
 **Use cases:**

--- a/custom_components/fenix_tft/__init__.py
+++ b/custom_components/fenix_tft/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import voluptuous as vol
@@ -75,6 +76,50 @@ FULL_HISTORY_BATCH_DAYS = 365  # Import "all history" in yearly chunks
 FULL_HISTORY_EARLIEST_DATE = dt_util.dt.datetime(
     2000, 1, 1, tzinfo=dt_util.UTC
 )  # Practical lower bound for progressive backfills
+
+
+@dataclass(slots=True)
+class HistoricalImportSummary:
+    """Track imported statistics, raw points, batches, and overall date range."""
+
+    imported_stat_count: int = 0
+    imported_raw_points: int = 0
+    imported_batches: int = 0
+    imported_range_start: dt_util.dt.datetime | None = None
+    imported_range_end: dt_util.dt.datetime | None = None
+
+    def track_range(
+        self,
+        batch_start_time: dt_util.dt.datetime | None,
+        batch_end_time: dt_util.dt.datetime | None,
+    ) -> None:
+        """Expand the tracked overall import range to include a batch."""
+        if batch_start_time and (
+            self.imported_range_start is None
+            or batch_start_time < self.imported_range_start
+        ):
+            self.imported_range_start = batch_start_time
+        if batch_end_time and (
+            self.imported_range_end is None or batch_end_time > self.imported_range_end
+        ):
+            self.imported_range_end = batch_end_time
+
+
+@dataclass(slots=True)
+class HistoricalImportPlan:
+    """Describe the date range a historical import should use."""
+
+    end_date: dt_util.dt.datetime
+    start_date: dt_util.dt.datetime | None = None
+    days_to_import: int | None = None
+    import_all_history: bool = False
+
+    def fixed_range(self) -> tuple[dt_util.dt.datetime, dt_util.dt.datetime, int]:
+        """Return the validated fixed-range import window."""
+        if self.start_date is None or self.days_to_import is None:
+            raise ValueError
+        return self.start_date, self.end_date, self.days_to_import
+
 
 # Service schemas
 SET_HOLIDAY_SCHEDULE_SCHEMA = vol.Schema(
@@ -284,6 +329,105 @@ def _calculate_import_end_date(
     return dt_util.as_utc(dt_util.start_of_local_day())
 
 
+def _prepare_historical_import_plan(
+    device_name: str,
+    days_back: int,
+    first_stat_time: dt_util.dt.datetime | None,
+    *,
+    import_all_history: bool,
+) -> HistoricalImportPlan:
+    """Build and log the date plan for a historical import request."""
+    if import_all_history:
+        end_date = _calculate_import_end_date(first_stat_time)
+        _LOGGER.info(
+            "Import strategy for '%s': progressive backfill before %s until %s",
+            device_name,
+            end_date.strftime("%Y-%m-%d %H:%M:%S"),
+            FULL_HISTORY_EARLIEST_DATE.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+        return HistoricalImportPlan(end_date=end_date, import_all_history=True)
+
+    start_date, end_date, days_to_import = _calculate_import_date_range(
+        days_back, first_stat_time
+    )
+    if first_stat_time:
+        _LOGGER.info(
+            "Import strategy for '%s': backfilling %d days before existing data "
+            "(first statistic: %s, import range: %s to %s)",
+            device_name,
+            days_back,
+            first_stat_time.strftime("%Y-%m-%d %H:%M:%S"),
+            start_date.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+    else:
+        _LOGGER.info(
+            "Import strategy for '%s': no existing statistics found, "
+            "importing %d days from present (import range: %s to %s)",
+            device_name,
+            days_back,
+            start_date.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+    return HistoricalImportPlan(
+        end_date=end_date,
+        start_date=start_date,
+        days_to_import=days_to_import,
+    )
+
+
+def _build_historical_import_start_message(
+    device_name: str,
+    plan: HistoricalImportPlan,
+    first_stat_time: dt_util.dt.datetime | None,
+) -> str:
+    """Create the start notification message for a historical import."""
+    if plan.import_all_history:
+        return (
+            f"Starting full historical data import for {device_name}. "
+            "Older energy history will be imported in yearly batches until no more "
+            "data is available. This may take a while."
+        )
+
+    import_msg = (
+        f"Starting historical data import for {device_name}. Importing "
+        f"{plan.days_to_import} days of energy data"
+    )
+    if first_stat_time:
+        import_msg += (
+            f" (before existing data from {first_stat_time.strftime('%Y-%m-%d')})"
+        )
+    return f"{import_msg}. This may take a while."
+
+
+def _build_historical_import_success_message(
+    device_name: str,
+    statistic_id: str,
+    summary: HistoricalImportSummary,
+) -> str:
+    """Create the completion notification message for a historical import."""
+    if not summary.imported_stat_count:
+        return (
+            f"No additional historical energy data was available for {device_name}. "
+            f"The external statistic ({statistic_id}) is up to date."
+        )
+
+    range_msg = ""
+    if summary.imported_range_start and summary.imported_range_end:
+        range_msg = (
+            f" Imported {summary.imported_stat_count} statistic point(s) covering "
+            f"{summary.imported_range_start.date()} to "
+            f"{summary.imported_range_end.date()} from "
+            f"{summary.imported_batches} batch(es)."
+        )
+    return (
+        f"Successfully imported historical energy data for {device_name}."
+        f"{range_msg} Data is available as an external statistic ({statistic_id}) "
+        "and can be added to the Energy Dashboard."
+    )
+
+
 async def _import_energy_statistics_batch(  # noqa: PLR0913
     hass: HomeAssistant,
     energy_entity_id: str,
@@ -322,6 +466,126 @@ async def _import_energy_statistics_batch(  # noqa: PLR0913
         energy_stats[0]["start"],
         energy_stats[-1]["start"],
     )
+
+
+async def _import_full_history_statistics(  # noqa: PLR0913
+    hass: HomeAssistant,
+    api: FenixTFTApi,
+    energy_entity_id: str,
+    energy_metadata: Any,
+    statistic_id: str,
+    installation_id: str,
+    room_id: str,
+    subscription_id: str,
+    device_name: str,
+    end_date: dt_util.dt.datetime,
+    first_stat_time: dt_util.dt.datetime | None,
+) -> HistoricalImportSummary:
+    """Import all available older history in yearly batches."""
+    summary = HistoricalImportSummary()
+    current_end = end_date
+    has_future_stats = first_stat_time is not None
+
+    while current_end > FULL_HISTORY_EARLIEST_DATE:
+        batch_start = max(
+            FULL_HISTORY_EARLIEST_DATE,
+            current_end - dt_util.dt.timedelta(days=FULL_HISTORY_BATCH_DAYS),
+        )
+        batch_days = (current_end - batch_start).days
+
+        all_energy_data = await _fetch_historical_energy_data(
+            api,
+            installation_id,
+            room_id,
+            subscription_id,
+            batch_start,
+            current_end,
+            batch_days,
+            device_name,
+            aggregation_reference_end_date=end_date,
+        )
+
+        if all_energy_data:
+            summary.imported_batches += 1
+            summary.imported_raw_points += len(all_energy_data)
+            (
+                batch_stat_count,
+                _batch_sum,
+                batch_range_start,
+                batch_range_end,
+            ) = await _import_energy_statistics_batch(
+                hass,
+                energy_entity_id,
+                energy_metadata,
+                statistic_id,
+                all_energy_data,
+                current_end if has_future_stats else None,
+            )
+            summary.imported_stat_count += batch_stat_count
+            summary.track_range(batch_range_start, batch_range_end)
+            has_future_stats = True
+
+        current_end = batch_start
+
+    return summary
+
+
+async def _import_fixed_range_statistics(  # noqa: PLR0913
+    hass: HomeAssistant,
+    api: FenixTFTApi,
+    energy_entity_id: str,
+    energy_metadata: Any,
+    statistic_id: str,
+    installation_id: str,
+    room_id: str,
+    subscription_id: str,
+    device_name: str,
+    start_date: dt_util.dt.datetime,
+    end_date: dt_util.dt.datetime,
+    days_to_import: int,
+    first_stat_time: dt_util.dt.datetime | None,
+) -> HistoricalImportSummary:
+    """Import one bounded historical range before the current horizon."""
+    summary = HistoricalImportSummary()
+
+    all_energy_data = await _fetch_historical_energy_data(
+        api,
+        installation_id,
+        room_id,
+        subscription_id,
+        start_date,
+        end_date,
+        days_to_import,
+        device_name,
+    )
+
+    if not all_energy_data:
+        _LOGGER.warning(
+            "No data fetched for '%s' in the requested date range (%s to %s). "
+            "The device may not have been active during this period.",
+            device_name,
+            start_date.strftime("%Y-%m-%d"),
+            end_date.strftime("%Y-%m-%d"),
+        )
+        return summary
+
+    summary.imported_batches = 1
+    summary.imported_raw_points = len(all_energy_data)
+    (
+        summary.imported_stat_count,
+        _batch_sum,
+        batch_range_start,
+        batch_range_end,
+    ) = await _import_energy_statistics_batch(
+        hass,
+        energy_entity_id,
+        energy_metadata,
+        statistic_id,
+        all_energy_data,
+        end_date if first_stat_time else None,
+    )
+    summary.track_range(batch_range_start, batch_range_end)
+    return summary
 
 
 def _determine_aggregation_period(
@@ -503,7 +767,7 @@ async def _fetch_historical_energy_data(  # noqa: PLR0913
     return all_energy_data
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG001, C901, PLR0915
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG001, PLR0915
     """Set up the Fenix TFT integration and register services."""
 
     async def async_set_holiday_schedule(call: ServiceCall) -> None:
@@ -628,7 +892,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
             installation_id,
         )
 
-    async def async_import_historical_statistics(  # noqa: PLR0912, PLR0915
+    async def async_import_historical_statistics(
         call: ServiceCall,
     ) -> None:
         """Handle import_historical_statistics service call."""
@@ -668,65 +932,18 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
 
         # Check if we have existing statistics in the external statistic
         first_stat_time = await get_first_statistic_time(hass, statistic_id)
-        end_date = _calculate_import_end_date(first_stat_time)
-
-        # Log import strategy
-        if import_all_history:
-            _LOGGER.info(
-                "Import strategy for '%s': progressive backfill before %s until %s",
-                device_name,
-                end_date.strftime("%Y-%m-%d %H:%M:%S"),
-                FULL_HISTORY_EARLIEST_DATE.strftime("%Y-%m-%d %H:%M:%S"),
-            )
-        elif first_stat_time:
-            start_date, _, days_to_import = _calculate_import_date_range(
-                days_back, first_stat_time
-            )
-            _LOGGER.info(
-                "Import strategy for '%s': backfilling %d days before existing data "
-                "(first statistic: %s, import range: %s to %s)",
-                device_name,
-                days_back,
-                first_stat_time.strftime("%Y-%m-%d %H:%M:%S"),
-                start_date.strftime("%Y-%m-%d %H:%M:%S"),
-                end_date.strftime("%Y-%m-%d %H:%M:%S"),
-            )
-        else:
-            start_date, _, days_to_import = _calculate_import_date_range(
-                days_back, first_stat_time
-            )
-            _LOGGER.info(
-                "Import strategy for '%s': no existing statistics found, "
-                "importing %d days from present (import range: %s to %s)",
-                device_name,
-                days_back,
-                start_date.strftime("%Y-%m-%d %H:%M:%S"),
-                end_date.strftime("%Y-%m-%d %H:%M:%S"),
-            )
+        plan = _prepare_historical_import_plan(
+            device_name,
+            days_back,
+            first_stat_time,
+            import_all_history=import_all_history,
+        )
 
         # Create start notification
         notification_id = f"fenix_import_{energy_entity_id.replace('.', '_')}"
-        if import_all_history:
-            import_msg = (
-                f"Starting full historical data import for {device_name}. "
-                "Older energy history will be imported in yearly batches until no "
-                "more data is available."
-            )
-        else:
-            import_msg = (
-                f"Starting historical data import for {device_name}. "
-                f"Importing {days_to_import} days of energy data"
-            )
-            if first_stat_time:
-                import_msg += (
-                    " (before existing data from "
-                    f"{first_stat_time.strftime('%Y-%m-%d')})"
-                )
-        import_msg += ". This may take a while."
-
         async_create(
             hass,
-            import_msg,
+            _build_historical_import_start_message(device_name, plan, first_stat_time),
             title="Fenix TFT Historical Import",
             notification_id=notification_id,
         )
@@ -765,138 +982,44 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
                 energy_entity_id, energy_entity_name
             )
 
-            imported_stat_count = 0
-            imported_raw_points = 0
-            imported_batches = 0
-            imported_range_start: dt_util.dt.datetime | None = None
-            imported_range_end: dt_util.dt.datetime | None = None
-
-            def _track_imported_range(
-                batch_start_time: dt_util.dt.datetime | None,
-                batch_end_time: dt_util.dt.datetime | None,
-            ) -> None:
-                nonlocal imported_range_start, imported_range_end
-                if batch_start_time and (
-                    imported_range_start is None
-                    or batch_start_time < imported_range_start
-                ):
-                    imported_range_start = batch_start_time
-                if batch_end_time and (
-                    imported_range_end is None or batch_end_time > imported_range_end
-                ):
-                    imported_range_end = batch_end_time
-
             if import_all_history:
-                current_end = end_date
-                has_future_stats = first_stat_time is not None
-
-                while current_end > FULL_HISTORY_EARLIEST_DATE:
-                    batch_start = max(
-                        FULL_HISTORY_EARLIEST_DATE,
-                        current_end
-                        - dt_util.dt.timedelta(days=FULL_HISTORY_BATCH_DAYS),
-                    )
-                    batch_days = (current_end - batch_start).days
-
-                    all_energy_data = await _fetch_historical_energy_data(
-                        api,
-                        installation_id,
-                        room_id,
-                        subscription_id,
-                        batch_start,
-                        current_end,
-                        batch_days,
-                        device_name,
-                        aggregation_reference_end_date=end_date,
-                    )
-
-                    if all_energy_data:
-                        imported_batches += 1
-                        imported_raw_points += len(all_energy_data)
-                        (
-                            batch_stat_count,
-                            _batch_sum,
-                            batch_range_start,
-                            batch_range_end,
-                        ) = await _import_energy_statistics_batch(
-                            hass,
-                            energy_entity_id,
-                            energy_metadata,
-                            statistic_id,
-                            all_energy_data,
-                            current_end if has_future_stats else None,
-                        )
-                        imported_stat_count += batch_stat_count
-                        _track_imported_range(batch_range_start, batch_range_end)
-                        has_future_stats = True
-
-                    current_end = batch_start
-            else:
-                start_date, end_date, days_to_import = _calculate_import_date_range(
-                    days_back, first_stat_time
-                )
-                all_energy_data = await _fetch_historical_energy_data(
+                summary = await _import_full_history_statistics(
+                    hass,
                     api,
+                    energy_entity_id,
+                    energy_metadata,
+                    statistic_id,
                     installation_id,
                     room_id,
                     subscription_id,
-                    start_date,
-                    end_date,
-                    days_back,
                     device_name,
-                )
-
-                if all_energy_data:
-                    imported_batches = 1
-                    imported_raw_points = len(all_energy_data)
-                    (
-                        imported_stat_count,
-                        _batch_sum,
-                        batch_range_start,
-                        batch_range_end,
-                    ) = await _import_energy_statistics_batch(
-                        hass,
-                        energy_entity_id,
-                        energy_metadata,
-                        statistic_id,
-                        all_energy_data,
-                        end_date if first_stat_time else None,
-                    )
-                    _track_imported_range(batch_range_start, batch_range_end)
-                else:
-                    _LOGGER.warning(
-                        "No data fetched for '%s' in the requested date range "
-                        "(%s to %s). "
-                        "The device may not have been active during this period.",
-                        device_name,
-                        start_date.strftime("%Y-%m-%d"),
-                        end_date.strftime("%Y-%m-%d"),
-                    )
-
-            # Success notification
-            if imported_stat_count:
-                range_msg = ""
-                if imported_range_start and imported_range_end:
-                    range_msg = (
-                        f" Imported {imported_stat_count} statistic point(s) "
-                        f"covering {imported_range_start.date()} to "
-                        f"{imported_range_end.date()} from "
-                        f"{imported_batches} batch(es)."
-                    )
-                success_msg = (
-                    f"Successfully imported historical energy data for {device_name}."
-                    f"{range_msg} Data is available as an external statistic "
-                    f"({statistic_id}) and can be added to the Energy Dashboard."
+                    plan.end_date,
+                    first_stat_time,
                 )
             else:
-                success_msg = (
-                    f"No additional historical energy data was available for "
-                    f"{device_name}. The external statistic ({statistic_id}) "
-                    "is up to date."
+                start_date, end_date, days_to_import = plan.fixed_range()
+                summary = await _import_fixed_range_statistics(
+                    hass,
+                    api,
+                    energy_entity_id,
+                    energy_metadata,
+                    statistic_id,
+                    installation_id,
+                    room_id,
+                    subscription_id,
+                    device_name,
+                    start_date,
+                    end_date,
+                    days_to_import,
+                    first_stat_time,
                 )
+
+            # Success notification
             async_create(
                 hass,
-                success_msg,
+                _build_historical_import_success_message(
+                    device_name, statistic_id, summary
+                ),
                 title="Fenix TFT Historical Import Complete",
                 notification_id=notification_id,
             )
@@ -905,9 +1028,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
                 "Historical import completed successfully for '%s': %d raw point(s), "
                 "%d statistic(s), %d batch(es)",
                 device_name,
-                imported_raw_points,
-                imported_stat_count,
-                imported_batches,
+                summary.imported_raw_points,
+                summary.imported_stat_count,
+                summary.imported_batches,
             )
 
         except (FenixTFTApiError, ServiceValidationError) as err:

--- a/custom_components/fenix_tft/__init__.py
+++ b/custom_components/fenix_tft/__init__.py
@@ -4,15 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import voluptuous as vol
 from homeassistant.components.persistent_notification import async_create
+from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import ATTR_ENTITY_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    UnitOfEnergy,
+)
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
@@ -29,6 +35,7 @@ from .const import (
     ATTR_DAYS_BACK,
     ATTR_END_DATE,
     ATTR_ENERGY_ENTITY,
+    ATTR_IMPORT_ALL_HISTORY,
     ATTR_MODE,
     ATTR_START_DATE,
     DOMAIN,
@@ -44,7 +51,6 @@ from .statistics import (
     convert_energy_api_data_to_statistics,
     create_energy_statistic_metadata,
     get_first_statistic_time,
-    get_last_statistic_sum,
 )
 
 
@@ -64,6 +70,11 @@ HOURLY_AGGREGATION_MAX_DAYS = 7  # Use hourly for last 7 days
 DAILY_AGGREGATION_MAX_DAYS = 90  # Use daily up to 90 days back
 DAILY_AGGREGATION_CHUNK_DAYS = 30  # Max days are included in each daily API call
 MONTHLY_AGGREGATION_MAX_DAYS = 365  # Use monthly beyond 90 days back
+YEARLY_AGGREGATION_CHUNK_DAYS = 365  # Use yearly requests for very old data
+FULL_HISTORY_BATCH_DAYS = 365  # Import "all history" in yearly chunks
+FULL_HISTORY_EARLIEST_DATE = dt_util.dt.datetime(
+    2000, 1, 1, tzinfo=dt_util.UTC
+)  # Practical lower bound for progressive backfills
 
 # Service schemas
 SET_HOLIDAY_SCHEDULE_SCHEMA = vol.Schema(
@@ -84,9 +95,10 @@ CANCEL_HOLIDAY_SCHEDULE_SCHEMA = vol.Schema(
 SERVICE_IMPORT_HISTORICAL_STATISTICS_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENERGY_ENTITY): cv.entity_id,
-        vol.Required(ATTR_DAYS_BACK): vol.All(
+        vol.Optional(ATTR_DAYS_BACK, default=30): vol.All(
             vol.Coerce(int), vol.Range(min=1, max=365)
         ),
+        vol.Optional(ATTR_IMPORT_ALL_HISTORY, default=False): cv.boolean,
     }
 )
 
@@ -259,8 +271,61 @@ def _calculate_import_date_range(
     return start_date, end_date, actual_days
 
 
+def _calculate_import_end_date(
+    first_stat_time: dt_util.dt.datetime | None,
+) -> dt_util.dt.datetime:
+    """Return the exclusive end boundary for historical imports."""
+    if first_stat_time:
+        existing_day_start_local = dt_util.as_local(first_stat_time).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        return dt_util.as_utc(existing_day_start_local)
+
+    return dt_util.as_utc(dt_util.start_of_local_day())
+
+
+async def _import_energy_statistics_batch(  # noqa: PLR0913
+    hass: HomeAssistant,
+    energy_entity_id: str,
+    energy_metadata: Any,
+    statistic_id: str,
+    energy_data: list[dict[str, object]],
+    rebase_future_from: dt_util.dt.datetime | None,
+) -> tuple[int, float, dt_util.dt.datetime | None, dt_util.dt.datetime | None]:
+    """Convert and queue one imported batch of external statistics."""
+    energy_stats = convert_energy_api_data_to_statistics(energy_data)
+    if not energy_stats:
+        return 0, 0.0, None, None
+
+    async_add_external_statistics(hass, energy_metadata, energy_stats)
+    imported_sum = float(energy_stats[-1]["sum"] or 0.0)
+
+    if rebase_future_from and imported_sum > 0:
+        get_instance(hass).async_adjust_statistics(
+            statistic_id,
+            rebase_future_from,
+            imported_sum,
+            UnitOfEnergy.WATT_HOUR,
+        )
+
+    _LOGGER.debug(
+        "Queued %d imported statistic(s) for '%s' (sum %.2f Wh, rebase_from=%s)",
+        len(energy_stats),
+        energy_entity_id,
+        imported_sum,
+        rebase_future_from.isoformat() if rebase_future_from else None,
+    )
+
+    return (
+        len(energy_stats),
+        imported_sum,
+        energy_stats[0]["start"],
+        energy_stats[-1]["start"],
+    )
+
+
 def _determine_aggregation_period(
-    days_back_from_end: int, remaining_days: int
+    days_back_from_reference: int, remaining_days: int
 ) -> tuple[str, int]:
     """
     Determine the aggregation period and chunk size based on how far back in time.
@@ -268,31 +333,37 @@ def _determine_aggregation_period(
     Uses dynamic aggregation:
     - Last 7 days: hourly aggregation for detail
     - 8-90 days ago: daily aggregation
-    - 91+ days ago: monthly aggregation
+    - 91-365 days ago: monthly aggregation
+    - 366+ days ago: yearly aggregation
 
     Args:
-        days_back_from_end: Number of days back from the end date
+        days_back_from_reference: Number of days back from the latest import horizon
         remaining_days: Number of remaining days to process
 
     Returns:
-        Tuple of (period, chunk_days) where period is "Hour", "Day", or "Month"
+        Tuple of (period, chunk_days) where period is "Hour", "Day", "Month",
+        or "Year"
 
     """
-    if days_back_from_end < HOURLY_AGGREGATION_MAX_DAYS:
+    if days_back_from_reference < HOURLY_AGGREGATION_MAX_DAYS:
         # Recent data: use hourly aggregation
         period = "Hour"
         chunk_days = min(
-            HOURLY_AGGREGATION_MAX_DAYS - days_back_from_end,
+            HOURLY_AGGREGATION_MAX_DAYS - days_back_from_reference,
             remaining_days,
         )
-    elif days_back_from_end < DAILY_AGGREGATION_MAX_DAYS:
+    elif days_back_from_reference < DAILY_AGGREGATION_MAX_DAYS:
         # Medium range: use daily aggregation
         period = "Day"
         chunk_days = min(DAILY_AGGREGATION_CHUNK_DAYS, remaining_days)
-    else:
+    elif days_back_from_reference < MONTHLY_AGGREGATION_MAX_DAYS:
         # Older data: use monthly aggregation
         period = "Month"
         chunk_days = min(MONTHLY_AGGREGATION_MAX_DAYS, remaining_days)
+    else:
+        # Very old data: use yearly aggregation to skip empty historical ranges fast
+        period = "Year"
+        chunk_days = min(YEARLY_AGGREGATION_CHUNK_DAYS, remaining_days)
 
     return period, chunk_days
 
@@ -306,6 +377,7 @@ async def _fetch_historical_energy_data(  # noqa: PLR0913
     end_date: dt_util.dt.datetime,
     days_back: int,
     device_name: str,
+    aggregation_reference_end_date: dt_util.dt.datetime | None = None,
 ) -> list[dict]:
     """
     Fetch historical energy data with dynamic aggregation.
@@ -324,6 +396,8 @@ async def _fetch_historical_energy_data(  # noqa: PLR0913
         end_date: End date for data fetch
         days_back: Total days to import
         device_name: Device name for logging
+        aggregation_reference_end_date: Horizon to measure data age from when
+            choosing Hour/Day/Month/Year aggregation. Defaults to ``end_date``.
 
     Returns:
         List of all fetched energy data points
@@ -345,14 +419,15 @@ async def _fetch_historical_energy_data(  # noqa: PLR0913
     remaining_days = days_back
     chunk_count = 0
     failed_chunks = 0
+    aggregation_reference_end_date = aggregation_reference_end_date or end_date
 
     while remaining_days > 0 and current_date > start_date:
         chunk_count += 1
 
         # Determine period and chunk size based on how far back we are
-        days_back_from_end = (end_date - current_date).days
+        days_back_from_reference = (aggregation_reference_end_date - current_date).days
         period, chunk_days = _determine_aggregation_period(
-            days_back_from_end, remaining_days
+            days_back_from_reference, remaining_days
         )
 
         # Calculate chunk boundaries
@@ -428,7 +503,7 @@ async def _fetch_historical_energy_data(  # noqa: PLR0913
     return all_energy_data
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG001, PLR0915
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG001, C901, PLR0915
     """Set up the Fenix TFT integration and register services."""
 
     async def async_set_holiday_schedule(call: ServiceCall) -> None:
@@ -553,16 +628,22 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
             installation_id,
         )
 
-    async def async_import_historical_statistics(call: ServiceCall) -> None:  # noqa: PLR0915
+    async def async_import_historical_statistics(  # noqa: PLR0912, PLR0915
+        call: ServiceCall,
+    ) -> None:
         """Handle import_historical_statistics service call."""
         energy_entity_id = call.data[ATTR_ENERGY_ENTITY]
         days_back = call.data[ATTR_DAYS_BACK]
+        import_all_history = call.data[ATTR_IMPORT_ALL_HISTORY]
 
         _LOGGER.info(
-            "Historical import service called for entity '%s': requesting %d days "
-            "of data",
+            "Historical import service called for entity '%s': %s",
             energy_entity_id,
-            days_back,
+            (
+                "requesting all available history"
+                if import_all_history
+                else f"requesting {days_back} day(s) of data"
+            ),
         )
 
         # Extract device context from entity
@@ -587,14 +668,20 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
 
         # Check if we have existing statistics in the external statistic
         first_stat_time = await get_first_statistic_time(hass, statistic_id)
-
-        # Calculate date range based on existing statistics
-        start_date, end_date, days_to_import = _calculate_import_date_range(
-            days_back, first_stat_time
-        )
+        end_date = _calculate_import_end_date(first_stat_time)
 
         # Log import strategy
-        if first_stat_time:
+        if import_all_history:
+            _LOGGER.info(
+                "Import strategy for '%s': progressive backfill before %s until %s",
+                device_name,
+                end_date.strftime("%Y-%m-%d %H:%M:%S"),
+                FULL_HISTORY_EARLIEST_DATE.strftime("%Y-%m-%d %H:%M:%S"),
+            )
+        elif first_stat_time:
+            start_date, _, days_to_import = _calculate_import_date_range(
+                days_back, first_stat_time
+            )
             _LOGGER.info(
                 "Import strategy for '%s': backfilling %d days before existing data "
                 "(first statistic: %s, import range: %s to %s)",
@@ -605,6 +692,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
                 end_date.strftime("%Y-%m-%d %H:%M:%S"),
             )
         else:
+            start_date, _, days_to_import = _calculate_import_date_range(
+                days_back, first_stat_time
+            )
             _LOGGER.info(
                 "Import strategy for '%s': no existing statistics found, "
                 "importing %d days from present (import range: %s to %s)",
@@ -616,15 +706,23 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
 
         # Create start notification
         notification_id = f"fenix_import_{energy_entity_id.replace('.', '_')}"
-        import_msg = (
-            f"Starting historical data import for {device_name}. "
-            f"Importing {days_to_import} days of energy data"
-        )
-        if first_stat_time:
-            import_msg += (
-                f" (before existing data from {first_stat_time.strftime('%Y-%m-%d')})"
+        if import_all_history:
+            import_msg = (
+                f"Starting full historical data import for {device_name}. "
+                "Older energy history will be imported in yearly batches until no "
+                "more data is available."
             )
-        import_msg += ". This will take about a minute."
+        else:
+            import_msg = (
+                f"Starting historical data import for {device_name}. "
+                f"Importing {days_to_import} days of energy data"
+            )
+            if first_stat_time:
+                import_msg += (
+                    " (before existing data from "
+                    f"{first_stat_time.strftime('%Y-%m-%d')})"
+                )
+        import_msg += ". This may take a while."
 
         async_create(
             hass,
@@ -656,110 +754,160 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
         )
 
         try:
-            # Fetch historical energy data with dynamic aggregation
-            all_energy_data = await _fetch_historical_energy_data(
-                api,
-                installation_id,
-                room_id,
-                subscription_id,
-                start_date,
-                end_date,
-                days_back,
-                device_name,
+            # Get entity friendly name from state which includes device name
+            energy_state = hass.states.get(energy_entity_id)
+            energy_entity_name = (
+                energy_state.name
+                if energy_state
+                else energy_entity_id.replace("_", " ").title()
+            )
+            energy_metadata = create_energy_statistic_metadata(
+                energy_entity_id, energy_entity_name
             )
 
-            # Process and import the data if available
-            if all_energy_data:
-                _LOGGER.info(
-                    "Processing %d raw data points for '%s' into statistics",
-                    len(all_energy_data),
-                    device_name,
-                )
+            imported_stat_count = 0
+            imported_raw_points = 0
+            imported_batches = 0
+            imported_range_start: dt_util.dt.datetime | None = None
+            imported_range_end: dt_util.dt.datetime | None = None
 
-                # Get entity friendly name from state which includes device name
-                energy_state = hass.states.get(energy_entity_id)
-                energy_entity_name = (
-                    energy_state.name
-                    if energy_state
-                    else energy_entity_id.replace("_", " ").title()
-                )
-                energy_metadata = create_energy_statistic_metadata(
-                    energy_entity_id, energy_entity_name
-                )
+            def _track_imported_range(
+                batch_start_time: dt_util.dt.datetime | None,
+                batch_end_time: dt_util.dt.datetime | None,
+            ) -> None:
+                nonlocal imported_range_start, imported_range_end
+                if batch_start_time and (
+                    imported_range_start is None
+                    or batch_start_time < imported_range_start
+                ):
+                    imported_range_start = batch_start_time
+                if batch_end_time and (
+                    imported_range_end is None or batch_end_time > imported_range_end
+                ):
+                    imported_range_end = batch_end_time
 
-                # Determine starting sum based on import strategy
-                # When backfilling BEFORE existing data, start from 0
-                # When importing without existing data, also start from 0
-                if first_stat_time:
-                    # Backfilling: start from 0 since importing BEFORE existing stats
-                    starting_sum = 0.0
-                    _LOGGER.debug(
-                        "Backfilling before existing data: starting cumulative sum "
-                        "at 0.0 Wh"
+            if import_all_history:
+                current_end = end_date
+                has_future_stats = first_stat_time is not None
+
+                while current_end > FULL_HISTORY_EARLIEST_DATE:
+                    batch_start = max(
+                        FULL_HISTORY_EARLIEST_DATE,
+                        current_end
+                        - dt_util.dt.timedelta(days=FULL_HISTORY_BATCH_DAYS),
                     )
-                else:
-                    # No existing stats: check if sensor has current state to
-                    # continue from
-                    starting_sum = await get_last_statistic_sum(
-                        hass, energy_metadata["statistic_id"]
+                    batch_days = (current_end - batch_start).days
+
+                    all_energy_data = await _fetch_historical_energy_data(
+                        api,
+                        installation_id,
+                        room_id,
+                        subscription_id,
+                        batch_start,
+                        current_end,
+                        batch_days,
+                        device_name,
+                        aggregation_reference_end_date=end_date,
                     )
-                    if starting_sum > 0:
-                        _LOGGER.debug(
-                            "Continuing from existing cumulative sum: %.2f Wh",
-                            starting_sum,
+
+                    if all_energy_data:
+                        imported_batches += 1
+                        imported_raw_points += len(all_energy_data)
+                        (
+                            batch_stat_count,
+                            _batch_sum,
+                            batch_range_start,
+                            batch_range_end,
+                        ) = await _import_energy_statistics_batch(
+                            hass,
+                            energy_entity_id,
+                            energy_metadata,
+                            statistic_id,
+                            all_energy_data,
+                            current_end if has_future_stats else None,
                         )
-                    else:
-                        _LOGGER.debug(
-                            "No existing statistics: starting cumulative sum at 0.0 Wh"
-                        )
+                        imported_stat_count += batch_stat_count
+                        _track_imported_range(batch_range_start, batch_range_end)
+                        has_future_stats = True
 
-                # Convert all data at once to maintain cumulative sum
-                all_energy_stats = convert_energy_api_data_to_statistics(
-                    all_energy_data, starting_sum
-                )
-
-                _LOGGER.debug(
-                    "Converted %d data points into %d statistics entries for '%s'",
-                    len(all_energy_data),
-                    len(all_energy_stats),
-                    device_name,
-                )
-
-                # Import statistics as external statistics
-                # This makes the data appear as a separate external statistic (e.g.,
-                # fenix_tft:victory_port_x_history) instead of interfering with the
-                # main sensor entity's current data
-                async_add_external_statistics(hass, energy_metadata, all_energy_stats)
-
-                _LOGGER.info(
-                    "Successfully imported %d statistics to external statistic '%s' "
-                    "(statistic_id: %s)",
-                    len(all_energy_stats),
-                    device_name,
-                    energy_metadata["statistic_id"],
-                )
+                    current_end = batch_start
             else:
-                _LOGGER.warning(
-                    "No data fetched for '%s' in the requested date range (%s to %s). "
-                    "The device may not have been active during this period.",
-                    device_name,
-                    start_date.strftime("%Y-%m-%d"),
-                    end_date.strftime("%Y-%m-%d"),
+                start_date, end_date, days_to_import = _calculate_import_date_range(
+                    days_back, first_stat_time
                 )
+                all_energy_data = await _fetch_historical_energy_data(
+                    api,
+                    installation_id,
+                    room_id,
+                    subscription_id,
+                    start_date,
+                    end_date,
+                    days_back,
+                    device_name,
+                )
+
+                if all_energy_data:
+                    imported_batches = 1
+                    imported_raw_points = len(all_energy_data)
+                    (
+                        imported_stat_count,
+                        _batch_sum,
+                        batch_range_start,
+                        batch_range_end,
+                    ) = await _import_energy_statistics_batch(
+                        hass,
+                        energy_entity_id,
+                        energy_metadata,
+                        statistic_id,
+                        all_energy_data,
+                        end_date if first_stat_time else None,
+                    )
+                    _track_imported_range(batch_range_start, batch_range_end)
+                else:
+                    _LOGGER.warning(
+                        "No data fetched for '%s' in the requested date range "
+                        "(%s to %s). "
+                        "The device may not have been active during this period.",
+                        device_name,
+                        start_date.strftime("%Y-%m-%d"),
+                        end_date.strftime("%Y-%m-%d"),
+                    )
 
             # Success notification
+            if imported_stat_count:
+                range_msg = ""
+                if imported_range_start and imported_range_end:
+                    range_msg = (
+                        f" Imported {imported_stat_count} statistic point(s) "
+                        f"covering {imported_range_start.date()} to "
+                        f"{imported_range_end.date()} from "
+                        f"{imported_batches} batch(es)."
+                    )
+                success_msg = (
+                    f"Successfully imported historical energy data for {device_name}."
+                    f"{range_msg} Data is available as an external statistic "
+                    f"({statistic_id}) and can be added to the Energy Dashboard."
+                )
+            else:
+                success_msg = (
+                    f"No additional historical energy data was available for "
+                    f"{device_name}. The external statistic ({statistic_id}) "
+                    "is up to date."
+                )
             async_create(
                 hass,
-                f"Successfully imported historical energy data for {device_name}. "
-                f"Data is available as an external statistic ({statistic_id}) "
-                f"and can be added to the Energy Dashboard.",
+                success_msg,
                 title="Fenix TFT Historical Import Complete",
                 notification_id=notification_id,
             )
 
             _LOGGER.info(
-                "Historical import completed successfully for '%s'",
+                "Historical import completed successfully for '%s': %d raw point(s), "
+                "%d statistic(s), %d batch(es)",
                 device_name,
+                imported_raw_points,
+                imported_stat_count,
+                imported_batches,
             )
 
         except (FenixTFTApiError, ServiceValidationError) as err:

--- a/custom_components/fenix_tft/const.py
+++ b/custom_components/fenix_tft/const.py
@@ -126,6 +126,7 @@ ATTR_START_DATE: Final[str] = "start_date"
 ATTR_END_DATE: Final[str] = "end_date"
 ATTR_MODE: Final[str] = "mode"
 ATTR_DAYS_BACK: Final[str] = "days_back"
+ATTR_IMPORT_ALL_HISTORY: Final[str] = "import_all_history"
 ATTR_ENERGY_ENTITY: Final[str] = "energy_entity"
 
 # Historical data import configuration

--- a/custom_components/fenix_tft/manifest.json
+++ b/custom_components/fenix_tft/manifest.json
@@ -17,5 +17,5 @@
         "aiohttp>=3.8.0",
         "beautifulsoup4>=4.11.0"
     ],
-    "version": "1.2.2"
+    "version": "1.3.0"
 }

--- a/custom_components/fenix_tft/services.yaml
+++ b/custom_components/fenix_tft/services.yaml
@@ -53,7 +53,7 @@ cancel_holiday_schedule:
 
 import_historical_statistics:
   name: Import historical statistics
-  description: Import historical energy consumption data as external statistics. Data will appear as a separate external statistic (e.g., fenix_tft:device_name_history) to avoid interfering with the main sensor's current data. Can be added to the Energy Dashboard. Supports up to 365 days with intelligent dynamic aggregation (hourly for last 7 days, daily for 8-90 days ago, monthly for older data). Check persistent notifications for progress updates.
+  description: Import historical energy consumption data as external statistics. Data will appear as a separate external statistic (e.g., fenix_tft:device_name_history) to avoid interfering with the main sensor's current data. Can be added to the Energy Dashboard. Supports targeted backfills with `days_back` or full-history imports in yearly batches. Check persistent notifications for progress updates.
   fields:
     energy_entity:
       name: Energy entity
@@ -66,11 +66,18 @@ import_historical_statistics:
           device_class: energy
     days_back:
       name: Days to import
-      description: Number of days of historical data to import (1-365). Recent data uses hourly aggregation for detail, older data uses daily/monthly aggregation for efficiency.
-      required: true
+      description: Number of days of historical data to import (1-365). Ignored when importing all available history.
+      required: false
       default: 30
       selector:
         number:
           min: 1
           max: 365
           mode: box
+    import_all_history:
+      name: Import all available history
+      description: Import all historical energy data available from Fenix in progressive yearly batches. When enabled, `days_back` is ignored.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/fenix_tft/translations/cs.json
+++ b/custom_components/fenix_tft/translations/cs.json
@@ -150,7 +150,7 @@
     },
     "import_historical_statistics": {
       "name": "Importovat historické statistiky",
-      "description": "Importovat historická data o spotřebě energie do dlouhodobých statistik Home Assistant. Používá inteligentní dynamické seskupování: hodinové pro posledních 7 dní, denní pro 8-90 dní dozadu, měsíční pro starší data.",
+      "description": "Importovat historická data o spotřebě energie do dlouhodobých statistik Home Assistant. Podporuje cílený import pomocí `days_back` i import celé historie v ročních dávkách.",
       "fields": {
         "energy_entity": {
           "name": "Entita spotřeby energie",
@@ -158,7 +158,11 @@
         },
         "days_back": {
           "name": "Počet dní k importu",
-          "description": "Počet dní historických dat k importu (1-365). Nedávná data budou s hodinovým detailem, starší s hrubším seskupením."
+          "description": "Počet dní historických dat k importu (1-365). Při zapnutí importu celé historie se ignoruje."
+        },
+        "import_all_history": {
+          "name": "Importovat celou dostupnou historii",
+          "description": "Importovat všechna historická energetická data dostupná z Fenixu v postupných ročních dávkách. Pokud je zapnuto, `days_back` se ignoruje."
         }
       }
     }

--- a/custom_components/fenix_tft/translations/de.json
+++ b/custom_components/fenix_tft/translations/de.json
@@ -150,7 +150,7 @@
     },
     "import_historical_statistics": {
       "name": "Historische Statistiken importieren",
-      "description": "Importiert historische Energieverbrauchsdaten in die Langzeitstatistiken von Home Assistant. Verwendet intelligente dynamische Aggregation: stündlich für die letzten 7 Tage, täglich für 8-90 Tage zurück, monatlich für ältere Daten.",
+      "description": "Importiert historische Energieverbrauchsdaten in die Langzeitstatistiken von Home Assistant. Unterstützt gezielte Backfills mit `days_back` oder den Import der gesamten Historie in Jahresblöcken.",
       "fields": {
         "energy_entity": {
           "name": "Energie-Entität",
@@ -158,7 +158,11 @@
         },
         "days_back": {
           "name": "Tage zum Importieren",
-          "description": "Anzahl der Tage historischer Daten zum Importieren (1-365). Aktuelle Daten werden stündlich detailliert, ältere Daten grober aggregiert."
+          "description": "Anzahl der Tage historischer Daten zum Importieren (1-365). Wird ignoriert, wenn die gesamte verfügbare Historie importiert wird."
+        },
+        "import_all_history": {
+          "name": "Gesamte verfügbare Historie importieren",
+          "description": "Importiert alle in Fenix verfügbaren historischen Energiedaten in fortlaufenden Jahresblöcken. Wenn aktiviert, wird `days_back` ignoriert."
         }
       }
     }

--- a/custom_components/fenix_tft/translations/en.json
+++ b/custom_components/fenix_tft/translations/en.json
@@ -150,7 +150,7 @@
     },
     "import_historical_statistics": {
       "name": "Import historical statistics",
-      "description": "Import historical energy consumption data as external statistics. Data will appear as a separate external statistic (e.g., fenix_tft:device_name_history) that can be added to the Energy Dashboard without interfering with the main sensor's current data. Uses intelligent dynamic aggregation: hourly for last 7 days, daily for 8-90 days ago, monthly for older data.",
+      "description": "Import historical energy consumption data as external statistics. Data will appear as a separate external statistic (e.g., fenix_tft:device_name_history) that can be added to the Energy Dashboard without interfering with the main sensor's current data. Supports targeted backfills with `days_back` or full-history imports in yearly batches.",
       "fields": {
         "energy_entity": {
           "name": "Energy entity",
@@ -158,7 +158,11 @@
         },
         "days_back": {
           "name": "Days to import",
-          "description": "Number of days of historical data to import (1-365). Recent data gets hourly detail, older data uses coarser aggregation."
+          "description": "Number of days of historical data to import (1-365). Ignored when importing all available history."
+        },
+        "import_all_history": {
+          "name": "Import all available history",
+          "description": "Import all historical energy data available from Fenix in progressive yearly batches. When enabled, `days_back` is ignored."
         }
       }
     }

--- a/custom_components/fenix_tft/translations/fr.json
+++ b/custom_components/fenix_tft/translations/fr.json
@@ -150,7 +150,7 @@
     },
     "import_historical_statistics": {
       "name": "Importer les statistiques historiques",
-      "description": "Importer les données historiques de consommation d'énergie dans les statistiques à long terme de Home Assistant. Utilise une agrégation dynamique intelligente : horaire pour les 7 derniers jours, quotidienne pour 8-90 jours en arrière, mensuelle pour les données plus anciennes.",
+      "description": "Importer les données historiques de consommation d'énergie dans les statistiques à long terme de Home Assistant. Prend en charge les imports ciblés avec `days_back` ou l'historique complet par lots annuels.",
       "fields": {
         "energy_entity": {
           "name": "Entité d'énergie",
@@ -158,7 +158,11 @@
         },
         "days_back": {
           "name": "Jours à importer",
-          "description": "Nombre de jours de données historiques à importer (1-365). Les données récentes auront des détails horaires, les données plus anciennes une agrégation plus grossière."
+          "description": "Nombre de jours de données historiques à importer (1-365). Ignoré si l'import de tout l'historique disponible est activé."
+        },
+        "import_all_history": {
+          "name": "Importer tout l'historique disponible",
+          "description": "Importer toutes les données historiques d'énergie disponibles depuis Fenix par lots annuels successifs. Quand activé, `days_back` est ignoré."
         }
       }
     }

--- a/custom_components/fenix_tft/translations/sk.json
+++ b/custom_components/fenix_tft/translations/sk.json
@@ -150,7 +150,7 @@
     },
     "import_historical_statistics": {
       "name": "Importovať historické štatistiky",
-      "description": "Importovať historické údaje o spotrebe energie do dlhodobých štatistík Home Assistant. Používa inteligentné dynamické zoskupovanie: hodinové pre posledných 7 dní, denné pre 8-90 dní dozadu, mesačné pre staršie údaje.",
+      "description": "Importovať historické údaje o spotrebe energie do dlhodobých štatistík Home Assistant. Podporuje cielené importy pomocou `days_back` aj import celej histórie v ročných dávkach.",
       "fields": {
         "energy_entity": {
           "name": "Entita spotreby energie",
@@ -158,7 +158,11 @@
         },
         "days_back": {
           "name": "Počet dní na import",
-          "description": "Počet dní historických údajov na import (1-365). Nedávne údaje budú s hodinovým detailom, staršie s hrubším zoskupením."
+          "description": "Počet dní historických údajov na import (1-365). Pri zapnutí importu celej histórie sa ignoruje."
+        },
+        "import_all_history": {
+          "name": "Importovať celú dostupnú históriu",
+          "description": "Importovať všetky historické energetické údaje dostupné z Fenixu v postupných ročných dávkach. Ak je zapnuté, `days_back` sa ignoruje."
         }
       }
     }

--- a/tests/components/fenix_tft/test_init.py
+++ b/tests/components/fenix_tft/test_init.py
@@ -127,7 +127,7 @@ async def test_import_historical_statistics_rebases_future_sums(
                 {"startDateOfMetric": "2025-02-01T00:00:00+00:00", "sum": 10.0},
                 {"startDateOfMetric": "2025-02-02T00:00:00+00:00", "sum": 5.0},
             ],
-        ),
+        ) as fetch_history,
         patch("custom_components.fenix_tft.async_add_external_statistics"),
         patch("custom_components.fenix_tft.get_instance", return_value=recorder),
     ):
@@ -141,6 +141,7 @@ async def test_import_historical_statistics_rebases_future_sums(
             blocking=True,
         )
 
+    assert fetch_history.await_args.args[6] == 28
     recorder.async_adjust_statistics.assert_called_once_with(
         "fenix_tft:home_living_room_daily_energy_consumption_history",
         import_end,
@@ -179,7 +180,7 @@ async def test_import_historical_statistics_without_existing_stats_skips_rebase(
             return_value=[
                 {"startDateOfMetric": "2025-02-01T00:00:00+00:00", "sum": 10.0},
             ],
-        ),
+        ) as fetch_history,
         patch("custom_components.fenix_tft.async_add_external_statistics"),
         patch("custom_components.fenix_tft.get_instance", return_value=recorder),
     ):
@@ -193,6 +194,7 @@ async def test_import_historical_statistics_without_existing_stats_skips_rebase(
             blocking=True,
         )
 
+    assert fetch_history.await_args.args[6] == 28
     recorder.async_adjust_statistics.assert_not_called()
 
 

--- a/tests/components/fenix_tft/test_init.py
+++ b/tests/components/fenix_tft/test_init.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.const import UnitOfEnergy
 from homeassistant.helpers import device_registry as dr
+from homeassistant.util import dt as dt_util
 
+from custom_components import fenix_tft
 from custom_components.fenix_tft import (
     async_migrate_entry,
     async_remove_config_entry_device,
@@ -13,6 +16,16 @@ from custom_components.fenix_tft import (
 from custom_components.fenix_tft.const import DOMAIN
 
 from .conftest import MOCK_DEVICE_ID
+
+
+def _get_energy_entity_id(hass) -> str:
+    """Return the Fenix daily energy sensor entity id."""
+    for state in hass.states.async_all("sensor"):
+        if state.entity_id.endswith("daily_energy_consumption"):
+            return state.entity_id
+
+    msg = "No Fenix daily energy sensor found"
+    raise AssertionError(msg)
 
 
 async def test_async_migrate_entry_current_version(hass, mock_config_entry, mock_api):
@@ -85,6 +98,208 @@ async def test_async_remove_config_entry_device_stale_device(
     )
 
     assert result is True
+
+
+async def test_import_historical_statistics_rebases_future_sums(
+    hass, setup_integration, mock_api
+):
+    """Prepending older history should rebase later cumulative statistics."""
+    mock_api.subscription_id = "subscription-123"
+    energy_entity_id = _get_energy_entity_id(hass)
+    import_end = dt_util.parse_datetime("2025-03-01T00:00:00+00:00")
+    assert import_end is not None
+    import_start = dt_util.parse_datetime("2025-02-01T00:00:00+00:00")
+    assert import_start is not None
+    recorder = MagicMock()
+
+    with (
+        patch(
+            "custom_components.fenix_tft.get_first_statistic_time",
+            return_value=import_end,
+        ),
+        patch(
+            "custom_components.fenix_tft._calculate_import_date_range",
+            return_value=(import_start, import_end, 28),
+        ),
+        patch(
+            "custom_components.fenix_tft._fetch_historical_energy_data",
+            return_value=[
+                {"startDateOfMetric": "2025-02-01T00:00:00+00:00", "sum": 10.0},
+                {"startDateOfMetric": "2025-02-02T00:00:00+00:00", "sum": 5.0},
+            ],
+        ),
+        patch("custom_components.fenix_tft.async_add_external_statistics"),
+        patch("custom_components.fenix_tft.get_instance", return_value=recorder),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "import_historical_statistics",
+            {
+                "energy_entity": energy_entity_id,
+                "days_back": 30,
+            },
+            blocking=True,
+        )
+
+    recorder.async_adjust_statistics.assert_called_once_with(
+        "fenix_tft:home_living_room_daily_energy_consumption_history",
+        import_end,
+        15.0,
+        UnitOfEnergy.WATT_HOUR,
+    )
+
+
+async def test_import_historical_statistics_without_existing_stats_skips_rebase(
+    hass, setup_integration, mock_api
+):
+    """Initial history imports should not shift future sums when none exist."""
+    mock_api.subscription_id = "subscription-123"
+    energy_entity_id = _get_energy_entity_id(hass)
+    import_end = dt_util.parse_datetime("2025-03-01T00:00:00+00:00")
+    assert import_end is not None
+    import_start = dt_util.parse_datetime("2025-02-01T00:00:00+00:00")
+    assert import_start is not None
+    recorder = MagicMock()
+
+    with (
+        patch(
+            "custom_components.fenix_tft.get_first_statistic_time",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.fenix_tft._calculate_import_end_date",
+            return_value=import_end,
+        ),
+        patch(
+            "custom_components.fenix_tft._calculate_import_date_range",
+            return_value=(import_start, import_end, 28),
+        ),
+        patch(
+            "custom_components.fenix_tft._fetch_historical_energy_data",
+            return_value=[
+                {"startDateOfMetric": "2025-02-01T00:00:00+00:00", "sum": 10.0},
+            ],
+        ),
+        patch("custom_components.fenix_tft.async_add_external_statistics"),
+        patch("custom_components.fenix_tft.get_instance", return_value=recorder),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "import_historical_statistics",
+            {
+                "energy_entity": energy_entity_id,
+                "days_back": 30,
+            },
+            blocking=True,
+        )
+
+    recorder.async_adjust_statistics.assert_not_called()
+
+
+async def test_import_historical_statistics_import_all_uses_yearly_batches(
+    hass, setup_integration, mock_api
+):
+    """Import-all should walk backwards in yearly batches and rebase older prepends."""
+    mock_api.subscription_id = "subscription-123"
+    energy_entity_id = _get_energy_entity_id(hass)
+    full_history_end = dt_util.parse_datetime("2026-01-01T00:00:00+00:00")
+    assert full_history_end is not None
+    full_history_start = dt_util.parse_datetime("2024-01-01T00:00:00+00:00")
+    assert full_history_start is not None
+    recorder = MagicMock()
+
+    with (
+        patch(
+            "custom_components.fenix_tft.get_first_statistic_time",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.fenix_tft._calculate_import_end_date",
+            return_value=full_history_end,
+        ),
+        patch(
+            "custom_components.fenix_tft.FULL_HISTORY_EARLIEST_DATE",
+            full_history_start,
+        ),
+        patch(
+            "custom_components.fenix_tft._fetch_historical_energy_data",
+            side_effect=[
+                [
+                    {
+                        "startDateOfMetric": "2025-01-01T00:00:00+00:00",
+                        "sum": 20.0,
+                    },
+                    {
+                        "startDateOfMetric": "2025-02-01T00:00:00+00:00",
+                        "sum": 30.0,
+                    },
+                ],
+                [
+                    {
+                        "startDateOfMetric": "2024-02-01T00:00:00+00:00",
+                        "sum": 8.0,
+                    }
+                ],
+                [],
+            ],
+        ) as fetch_history,
+        patch("custom_components.fenix_tft.async_add_external_statistics") as add_stats,
+        patch("custom_components.fenix_tft.get_instance", return_value=recorder),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "import_historical_statistics",
+            {
+                "energy_entity": energy_entity_id,
+                "import_all_history": True,
+            },
+            blocking=True,
+        )
+
+    assert fetch_history.call_count == 3
+    assert add_stats.call_count == 2
+    recorder.async_adjust_statistics.assert_called_once_with(
+        "fenix_tft:home_living_room_daily_energy_consumption_history",
+        dt_util.parse_datetime("2025-01-01T00:00:00+00:00"),
+        8.0,
+        UnitOfEnergy.WATT_HOUR,
+    )
+
+
+async def test_fetch_historical_energy_data_uses_yearly_aggregation_for_old_ranges():
+    """Very old full-history batches should skip directly to yearly requests."""
+    api = AsyncMock()
+    api.get_room_historical_energy.return_value = []
+
+    start_date = dt_util.parse_datetime("2000-05-15T00:00:00+00:00")
+    end_date = dt_util.parse_datetime("2001-05-15T00:00:00+00:00")
+    reference_end_date = dt_util.parse_datetime("2026-05-10T00:00:00+00:00")
+    assert start_date is not None
+    assert end_date is not None
+    assert reference_end_date is not None
+
+    with patch("custom_components.fenix_tft.asyncio.sleep", return_value=None):
+        result = await fenix_tft._fetch_historical_energy_data(
+            api,
+            "installation-id",
+            "room-id",
+            "subscription-id",
+            start_date,
+            end_date,
+            365,
+            "Bedroom",
+            aggregation_reference_end_date=reference_end_date,
+        )
+
+    assert result == []
+    api.get_room_historical_energy.assert_awaited_once_with(
+        "installation-id",
+        "room-id",
+        "subscription-id",
+        start_date,
+        end_date,
+        "Year",
+    )
 
 
 async def test_async_remove_config_entry_device_no_runtime_data(


### PR DESCRIPTION
- Introduced `import_all_history` option for full-history energy statistics import via `fenix_tft.import_historical_statistics`.
- Implemented yearly batching for very old history ranges to enhance backfill efficiency.
- Made `days_back` optional with a default of 30 days for targeted historical backfills.
- Updated service descriptions, README documentation, and translations to reflect new import flow.
- Fixed rebasing of external statistic sums during historical backfills to maintain cumulative totals.
- Improved historical import notifications for better clarity on imported ranges and progress.

## Summary by Sourcery

Add support for full-history energy statistics imports with yearly batching and improved historical backfill handling for the Fenix TFT integration.

New Features:
- Introduce an `import_all_history` option on the historical statistics import service to fetch all available energy data in progressive yearly batches.
- Default the `days_back` parameter for historical imports to 30 days while keeping it optional for targeted backfills.
- Extend historical data fetching to use yearly aggregation for very old ranges to speed up long backfills.

Bug Fixes:
- Ensure prepending older statistics rebases later external statistic sums so cumulative energy totals remain continuous.
- Skip rebasing of future statistics when performing an initial history import with no existing stats.

Enhancements:
- Improve historical import notifications and logging to better describe strategies, imported ranges, and batch progress.
- Refactor historical import to batch conversion and import of statistics for clearer range tracking and recorder adjustment.

Documentation:
- Update README, changelog, service descriptions, and translations to document the new full-history import behavior and options.

Tests:
- Add tests covering rebasing behavior when backfilling, non-rebasing on initial import, yearly batch full-history imports, and yearly aggregation for very old ranges.